### PR TITLE
Modify Makefile to add "include" rules for headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,33 @@
-NAME        = Webserv
+NAME        = webserv
 
 SRC_DIR     = src
 OBJ_DIR     = obj
 INC_DIR     = inc
 
-SERVER_SRC  = server.cpp ServerConfiguration.cpp main.cpp HttpRequest.cpp HttpResponse.cpp utils.cpp
+SRC  = server.cpp ServerConfiguration.cpp main.cpp HttpRequest.cpp HttpResponse.cpp utils.cpp
 INC_FILES   = webserv.hpp ServerConfiguration.hpp HttpRequest.hpp HttpResponse.hpp
 
-SERVER_OBJ  = $(addprefix $(OBJ_DIR)/,$(patsubst %.cpp,%.o,$(SERVER_SRC)))
+OBJ         = $(addprefix $(OBJ_DIR)/,$(patsubst %.cpp,%.o,$(SRC)))
 INCS        = $(addprefix $(INC_DIR)/,$(INC_FILES))
 
 CC          = c++
 CFLAGS      = -Wall -Wextra -Werror -std=c++98
 
-SERVER_EXEC = server.exe
+all: $(NAME)
+
+$(NAME): $(OBJ)
+	$(CC) $(CFLAGS) $(OBJ)  -o $(NAME)
 
 
-all: $(SERVER_EXEC)
-
-$(SERVER_EXEC): $(SERVER_OBJ)
-	$(CC) $(CFLAGS) $(SERVER_OBJ) -o $(SERVER_EXEC)
-
-
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(INCS)
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 	mkdir -p $(OBJ_DIR)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -Iinc/ -c $< -o $@
 
 clean:
 	rm -rf $(OBJ_DIR)
 
 fclean: clean
-	rm -rf $(SERVER_EXEC)
+	rm -rf $(NAME)
 
 re: fclean all
 

--- a/inc/HttpRequest.hpp
+++ b/inc/HttpRequest.hpp
@@ -1,6 +1,6 @@
 #pragma once
 //to do : vars private, getter & setter
-#include "../inc/webserv.hpp"
+#include "webserv.hpp"
 class ServerConfiguration;
 class HttpRequest {
     public:

--- a/src/HttpRequest.cpp
+++ b/src/HttpRequest.cpp
@@ -1,5 +1,5 @@
 
-#include "../inc/HttpRequest.hpp"
+#include "HttpRequest.hpp"
 
 void HttpRequest::parseRequest(std::string rawRequest, const ServerConfiguration& config){
     std::string method, path, body, line;

--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -1,5 +1,5 @@
 
-#include "../inc/HttpResponse.hpp"
+#include "HttpResponse.hpp"
 // constructor
 HttpResponse::HttpResponse(const HttpRequest& clientRequest){
     analyseRequest(clientRequest);

--- a/src/ServerConfiguration.cpp
+++ b/src/ServerConfiguration.cpp
@@ -1,5 +1,5 @@
 
-#include "../inc/ServerConfiguration.hpp"
+#include "ServerConfiguration.hpp"
 
 
 ServerConfiguration::ServerConfiguration(const std::string& configFile) : port_(0), document_root_(""), log_file_(""),log_level_("")  {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 
-#include "../inc/webserv.hpp"
+#include "webserv.hpp"
 int main (int argc, char **argv){
     if(argc != 2){
         std::cerr << "The servers takes 1 argument, which is the path to a configuration file" << std::endl;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,4 +1,4 @@
-#include "../inc/webserv.hpp"
+#include "webserv.hpp"
 
 //parse and analyse the resquest on the client socket. After send the appropriate response to the client.
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,4 @@
-#include "../inc/webserv.hpp"
+#include "webserv.hpp"
 
 //extract a string from a file
 std::string extractFileContent(const std::string& path) {


### PR DESCRIPTION
I've modified the Makefile so that instead of having full path as the header (ex: ../inc/HttpRequest.hpp) we simply have the "HttpRequest.hpp". Code is cleaner this way! 