### PR TITLE
Config file parsing (tristan 15/06/23)

### DIFF
--- a/config_file_parsing/ConfigFile.cpp
+++ b/config_file_parsing/ConfigFile.cpp
@@ -38,7 +38,7 @@ ConfigFile::ConfigFile(std::string configPath): _server_name(""), _root(""),
 ConfigFile::ConfigFile(std::string configPath, int index_of_server): _server_name(""), _root(""),
 	 _index(""), _access_log(""), _error_log(""), _include_types(""),
 	 _fd_path(configPath), _server_nb(index_of_server), _max_server_nb(0){
-	find_nb_of_server();
+	find_nb_of_server(_fd_path);
 	extract_config_file();
 }
 
@@ -52,13 +52,13 @@ void	ConfigFile::set_config(std::string configPath, int nb_of_server){
 	_error_log = "";
 	_include_types = "";
 	_fd_path = configPath;
-	_server_nb = nb_of_server;
+	_server_nb = nb_of_server + 1;
 	_max_server_nb = 0;
 	_location.clear();
 	_error_page.clear();
 	_listen.clear();
 	_methods.clear();
-	find_nb_of_server();
+	find_nb_of_server(_fd_path);
 	extract_config_file();
 }
 
@@ -195,28 +195,29 @@ void	set_struct_empty(ConfigFile::location& value){
 	value._loc_cgi_pass2 = "";
 }
 
-void	ConfigFile::find_nb_of_server(){
-	std::ifstream	infile(_fd_path);
+int	ConfigFile::find_nb_of_server(std::string path){
+	std::ifstream	infile(path);
 	if (!infile){
 		throw EmptyFd();
-		return ;
+		return (1);
 	}
 	std::string buffer;
-	std::regex 	server("server \\s*\\{");
-	int			i = 0;
+	std::regex 	server("server \\{");
+	int			count = 0;
 
 	if (infile.is_open()){
 		while(getline(infile, buffer)){
 			if (std::regex_search(buffer, server))
-				i++;
+				count++;
 		}
 	}
-	if (i <= 0)
+	if (count <= 0)
 		_max_server_nb = -1;
 	else
-		_max_server_nb = i;
+		_max_server_nb = count;
 	if (_server_nb > _max_server_nb)
 		throw std::runtime_error("Trying to create more configuration file object than the number of server block in the file.");
+	return (count);
 }
 
 void	ConfigFile::extract_config_file(){
@@ -250,8 +251,7 @@ void	ConfigFile::extract_config_file(){
 	std::regex	ret("return");
 	std::regex	cgi_pass("cgi_pass");
 	std::regex	cgi_pass2("cgi_pass2");
-	std::regex 	server("server \\s*\\{");
-
+	std::regex 	server("server \\{");
 
 	if (infile.is_open()){
 		int i = 0;
@@ -350,5 +350,7 @@ void	ConfigFile::extract_config_file(){
 		}
 		
 	}
+	else
+		throw std::runtime_error("Something failed");
 }
 

--- a/config_file_parsing/ConfigFile.hpp
+++ b/config_file_parsing/ConfigFile.hpp
@@ -60,7 +60,7 @@ class ConfigFile{
 		std::string 								get_index()const {return (this->_index);};
 
 		void										set_config(std::string configPath, int nb_of_server);
-		void										find_nb_of_server();
+		int											find_nb_of_server(std::string path);
 		void 										extract_config_file();
 		void										parse_listen(std::string str);
 		std::vector<std::string>					parse_location_listen(std::string str);

--- a/config_file_parsing/ConfigFile.hpp
+++ b/config_file_parsing/ConfigFile.hpp
@@ -8,7 +8,6 @@
 //#*     YP      YP       `"Ybbd8"'  8Y"Ybbd8"'   `"YbbdP"'   `"Ybbd8"'  88              "8"     *# 
 //#*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*#
 
-
 #ifndef CONFIGFILE_HPP
 #define CONFIGFILE_HPP
 
@@ -18,15 +17,18 @@
 #include<iostream>
 #include<regex>
 #include<map>
+#include<stdexcept>
 #include<vector>
 #include<sstream>
 #include<utility>
+#include<unistd.h>
 #include"color.h"
-
 
 class ConfigFile{
 	public:
+	ConfigFile();
 	ConfigFile(std::string configPath);
+	ConfigFile(std::string configPath, int index);
 	~ConfigFile();
 		//LOCATION STRUCTURE
 		struct location{
@@ -36,6 +38,7 @@ class ConfigFile{
 			std::string								_loc_server_name;
 			std::string								_loc_root;
 			std::string								_loc_access_log;
+			std::string								_loc_error_log;
 			std::string								_loc_include_types;
 			std::string								_loc_index;
 			std::string								_loc_auto_index;
@@ -45,15 +48,19 @@ class ConfigFile{
 			std::vector<std::string>				_loc_methods;
 		};
 
-		std::string 								get_server_name()const {return (_server_name);};
-		std::string 								get_root()const {return (_root);};
-		std::string 								get_access_log()const {return (_access_log);};
-		std::string 								get_include_types()const {return (_include_types);};
-		std::vector<std::string>&					get_methods(){return (_methods);};
-		std::vector<std::string>& 					get_listen(){return (_listen);};
-		std::map<std::string, std::string>&			get_error_page(){return (_error_page);};
-		const std::vector<ConfigFile::location>&	get_location()const{return (_location);};
+		std::string 								get_server_name()const {return (this->_server_name);};
+		std::string 								get_root()const {return (this->_root);};
+		std::string 								get_access_log()const {return (this->_access_log);};
+		std::string 								get_error_log()const {return (this->_error_log);};
+		std::string 								get_include_types()const {return (this->_include_types);};
+		const std::vector<std::string>&				get_methods()const {return (this->_methods);};
+		std::vector<std::string>& 					get_listen(){return (this->_listen);};
+		std::map<std::string, std::string>&			get_error_page(){return (this->_error_page);};
+		const std::vector<ConfigFile::location>&	get_location()const{return (this->_location);};
+		std::string 								get_index()const {return (this->_index);};
 
+		void										set_config(std::string configPath, int nb_of_server);
+		void										find_nb_of_server();
 		void 										extract_config_file();
 		void										parse_listen(std::string str);
 		std::vector<std::string>					parse_location_listen(std::string str);
@@ -73,7 +80,7 @@ class ConfigFile{
 
 
 
-
+	
 	private:
 		//CONFIG FILE VARIABLES
 		std::vector<location>					_location;
@@ -84,10 +91,13 @@ class ConfigFile{
 		std::string								_root;
 		std::string								_index;
 		std::string								_access_log;
+		std::string								_error_log;
 		std::string								_include_types;
 
 		//PATH TO THE CONFIG FILE
 		std::string 							_fd_path;
+		int										_server_nb;
+		int										_max_server_nb;
 };
 
 #endif

--- a/config_file_parsing/ConfigFile2.hpp
+++ b/config_file_parsing/ConfigFile2.hpp
@@ -8,6 +8,7 @@
 //#*     YP      YP       `"Ybbd8"'  8Y"Ybbd8"'   `"YbbdP"'   `"Ybbd8"'  88              "8"     *# 
 //#*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*#
 
+
 #ifndef CONFIGFILE_HPP
 #define CONFIGFILE_HPP
 
@@ -20,14 +21,12 @@
 #include<vector>
 #include<sstream>
 #include<utility>
-#include<unistd.h>
 #include"color.h"
+
 
 class ConfigFile{
 	public:
-	ConfigFile();
 	ConfigFile(std::string configPath);
-	ConfigFile(std::string configPath, int index);
 	~ConfigFile();
 		//LOCATION STRUCTURE
 		struct location{
@@ -37,7 +36,6 @@ class ConfigFile{
 			std::string								_loc_server_name;
 			std::string								_loc_root;
 			std::string								_loc_access_log;
-			std::string								_loc_error_log;
 			std::string								_loc_include_types;
 			std::string								_loc_index;
 			std::string								_loc_auto_index;
@@ -50,16 +48,12 @@ class ConfigFile{
 		std::string 								get_server_name()const {return (_server_name);};
 		std::string 								get_root()const {return (_root);};
 		std::string 								get_access_log()const {return (_access_log);};
-		std::string 								get_error_log()const {return (_error_log);};
 		std::string 								get_include_types()const {return (_include_types);};
-		const std::vector<std::string>&				get_methods()const {return (_methods);};
+		std::vector<std::string>&					get_methods(){return (_methods);};
 		std::vector<std::string>& 					get_listen(){return (_listen);};
 		std::map<std::string, std::string>&			get_error_page(){return (_error_page);};
 		const std::vector<ConfigFile::location>&	get_location()const{return (_location);};
-		std::string 								get_index()const {return (_index);};
 
-		void										set_config(std::string configPath, int nb_of_server);
-		void										find_nb_of_server();
 		void 										extract_config_file();
 		void										parse_listen(std::string str);
 		std::vector<std::string>					parse_location_listen(std::string str);
@@ -79,7 +73,7 @@ class ConfigFile{
 
 
 
-	
+
 	private:
 		//CONFIG FILE VARIABLES
 		std::vector<location>					_location;
@@ -90,13 +84,10 @@ class ConfigFile{
 		std::string								_root;
 		std::string								_index;
 		std::string								_access_log;
-		std::string								_error_log;
 		std::string								_include_types;
 
 		//PATH TO THE CONFIG FILE
 		std::string 							_fd_path;
-		int										_server_nb;
-		int										_max_server_nb;
 };
 
 #endif

--- a/config_file_parsing/Makefile
+++ b/config_file_parsing/Makefile
@@ -3,7 +3,7 @@ NAME = config
 SRCS = maintest.cpp \
 		ConfigFile.cpp \
 
-CFLAGS = -Wall -Wextra -Werror -g -std=c++98
+CFLAGS = -Wall -Wextra -Werror= -std=c++98 -g
 CC = c++
 
 OBJS = $(SRCS:%cpp=%o)

--- a/config_file_parsing/config3.conf
+++ b/config_file_parsing/config3.conf
@@ -24,3 +24,29 @@ server {
 		root	 /data/www/toto;
 	}
 }
+server {
+	listen 127.0.0.1:8080 localhost:8081 8888; #should be host:port or port
+	listen localhost:8081;
+	server_name  	webserv webserv1;
+	methods 		GET POST DELETE;
+	error_page		400 400.html;
+	error_page		405 405.html;
+	error_page		404 404.html;
+	client_size		10;
+	location / {
+		index	 index.html;
+	}
+	location /upload{
+		listen	8000;
+		listen	8001;
+		root 	/data/tmp/;
+		index	 index.html;
+		methods 		POST;
+		redirection		/telecharger;
+		error_page		400 400v2.html;
+		error_page		401 400v2.html;
+	}
+	location /toto {
+		root	 /data/www/toto;
+	}
+}

--- a/config_file_parsing/maintest.cpp
+++ b/config_file_parsing/maintest.cpp
@@ -47,6 +47,48 @@ int main() {
             }
         }
         std::cout << test[0].get_include_types() << std::endl;
+
+		std::cout << "/n/n/n/" << std::endl;
+
+        std::vector<std::string> temp_listen1 = test[1].get_listen();
+        for (size_t i = 0; i < temp_listen.size(); i++) {
+            std::cout << "Key: " << temp_listen1[i] << std::endl;
+        }
+		std::cout << "test" << std::endl;
+        std::cout << test[1].get_server_name() << std::endl;
+        std::cout << test[1].get_root() << std::endl;
+        std::cout << test[1].get_access_log() << std::endl;
+        std::cout << test[1].get_methods()[0] << std::endl;
+        std::cout << test[1].get_methods()[1] << std::endl;
+        std::cout << test[1].get_methods()[2] << std::endl;
+        std::map<std::string, std::string>::const_iterator iter1;
+        std::map<std::string, std::string> temp_error_page1 = test[1].get_error_page();
+        for (iter1 = temp_error_page1.begin(); iter1 != temp_error_page1.end(); ++iter1) {
+            std::cout << "Key: " << iter1->first << ", Value: " << iter1->second << std::endl;
+        }
+        std::vector<ConfigFile::location>::const_iterator it1;
+        std::vector<ConfigFile::location> temp_location1 = test[1].get_location();
+        for (it1 = temp_location1.begin(); it1 != temp_location1.end(); ++it1) {
+            std::cout << "Location: " << it1->_loc_location << std::endl;
+            for (size_t i = 0; i < it1->_loc_listen.size(); i++) {
+                std::cout << "  Listen: " << it1->_loc_listen[i] << std::endl;
+            }
+            std::cout << "  Server Name: " << it1->_loc_server_name << std::endl;
+            std::cout << "  Root: " << it1->_loc_root << std::endl;
+            std::cout << "  Access Log: " << it1->_loc_access_log << std::endl;
+            std::cout << "  Include Types: " << it1->_loc_include_types << std::endl;
+            std::cout << "  Index: " << it1->_loc_index << std::endl;
+            std::cout << "  Methods:" << std::endl;
+            for (size_t i = 0; i < it1->_loc_methods.size(); i++) {
+                std::cout << "    " << it1->_loc_methods[i] << std::endl;
+            }
+            std::cout << "  Error Log:" << std::endl;
+            std::map<std::string, std::string>::const_iterator errorLogIt1;
+            for (errorLogIt1 = it1->_loc_error_page.begin(); errorLogIt1 != it1->_loc_error_page.end(); ++errorLogIt1) {
+                std::cout << "    Key: " << errorLogIt1->first << ", Value: " << errorLogIt1->second << std::endl;
+            }
+        }
+        std::cout << test[1].get_include_types() << std::endl;
     } catch (const std::exception& e) {
         std::cerr << e.what() << '\n';
     }

--- a/config_file_parsing/maintest.cpp
+++ b/config_file_parsing/maintest.cpp
@@ -3,24 +3,29 @@
 int main() {
     std::string testfile = "./config3.conf";
     try {
-        ConfigFile test(testfile);
-        std::vector<std::string> temp_listen = test.get_listen();
+		ConfigFile* test = new ConfigFile[2];
+    	test[0].set_config(testfile, 0);
+    	test[1].set_config(testfile, 1);
+
+		
+        std::vector<std::string> temp_listen = test[0].get_listen();
         for (size_t i = 0; i < temp_listen.size(); i++) {
             std::cout << "Key: " << temp_listen[i] << std::endl;
         }
-        std::cout << test.get_server_name() << std::endl;
-        std::cout << test.get_root() << std::endl;
-        std::cout << test.get_access_log() << std::endl;
-        std::cout << test.get_methods()[0] << std::endl;
-        std::cout << test.get_methods()[1] << std::endl;
-        std::cout << test.get_methods()[2] << std::endl;
+		std::cout << "test" << std::endl;
+        std::cout << test[0].get_server_name() << std::endl;
+        std::cout << test[0].get_root() << std::endl;
+        std::cout << test[0].get_access_log() << std::endl;
+        std::cout << test[0].get_methods()[0] << std::endl;
+        std::cout << test[0].get_methods()[1] << std::endl;
+        std::cout << test[0].get_methods()[2] << std::endl;
         std::map<std::string, std::string>::const_iterator iter;
-        std::map<std::string, std::string> temp_error_page = test.get_error_page();
+        std::map<std::string, std::string> temp_error_page = test[0].get_error_page();
         for (iter = temp_error_page.begin(); iter != temp_error_page.end(); ++iter) {
             std::cout << "Key: " << iter->first << ", Value: " << iter->second << std::endl;
         }
         std::vector<ConfigFile::location>::const_iterator it;
-        std::vector<ConfigFile::location> temp_location = test.get_location();
+        std::vector<ConfigFile::location> temp_location = test[0].get_location();
         for (it = temp_location.begin(); it != temp_location.end(); ++it) {
             std::cout << "Location: " << it->_loc_location << std::endl;
             for (size_t i = 0; i < it->_loc_listen.size(); i++) {
@@ -41,7 +46,7 @@ int main() {
                 std::cout << "    Key: " << errorLogIt->first << ", Value: " << errorLogIt->second << std::endl;
             }
         }
-        std::cout << test.get_include_types() << std::endl;
+        std::cout << test[0].get_include_types() << std::endl;
     } catch (const std::exception& e) {
         std::cerr << e.what() << '\n';
     }

--- a/inc/ConfigFile.hpp
+++ b/inc/ConfigFile.hpp
@@ -26,6 +26,7 @@
 class ConfigFile{
 	public:
 	ConfigFile(std::string configPath);
+	ConfigFile(std::string configPath, int index);
 	~ConfigFile();
 		//LOCATION STRUCTURE
 		struct location{
@@ -56,6 +57,7 @@ class ConfigFile{
 		const std::vector<ConfigFile::location>&	get_location()const{return (_location);};
 		std::string 								get_index()const {return (_index);};
 
+		void										find_nb_of_server();
 		void 										extract_config_file();
 		void										parse_listen(std::string str);
 		std::vector<std::string>					parse_location_listen(std::string str);
@@ -81,7 +83,7 @@ class ConfigFile{
 		std::vector<location>					_location;
 		std::map<std::string, std::string>		_error_page;
 		std::vector<std::string>				_listen;
-		std::vector<std::string>			_methods;
+		std::vector<std::string>				_methods;
 		std::string								_server_name;
 		std::string								_root;
 		std::string								_index;
@@ -91,6 +93,8 @@ class ConfigFile{
 
 		//PATH TO THE CONFIG FILE
 		std::string 							_fd_path;
+		int										_server_nb;
+		int										_max_server_nb;
 };
 
 #endif

--- a/inc/ConfigFile.hpp
+++ b/inc/ConfigFile.hpp
@@ -17,6 +17,7 @@
 #include<iostream>
 #include<regex>
 #include<map>
+#include<stdexcept>
 #include<vector>
 #include<sstream>
 #include<utility>
@@ -47,19 +48,19 @@ class ConfigFile{
 			std::vector<std::string>				_loc_methods;
 		};
 
-		std::string 								get_server_name()const {return (_server_name);};
-		std::string 								get_root()const {return (_root);};
-		std::string 								get_access_log()const {return (_access_log);};
-		std::string 								get_error_log()const {return (_error_log);};
-		std::string 								get_include_types()const {return (_include_types);};
-		const std::vector<std::string>&				get_methods()const {return (_methods);};
-		std::vector<std::string>& 					get_listen(){return (_listen);};
-		std::map<std::string, std::string>&			get_error_page(){return (_error_page);};
-		const std::vector<ConfigFile::location>&	get_location()const{return (_location);};
-		std::string 								get_index()const {return (_index);};
+		std::string 								get_server_name()const {return (this->_server_name);};
+		std::string 								get_root()const {return (this->_root);};
+		std::string 								get_access_log()const {return (this->_access_log);};
+		std::string 								get_error_log()const {return (this->_error_log);};
+		std::string 								get_include_types()const {return (this->_include_types);};
+		const std::vector<std::string>&				get_methods()const {return (this->_methods);};
+		std::vector<std::string>& 					get_listen(){return (this->_listen);};
+		std::map<std::string, std::string>&			get_error_page(){return (this->_error_page);};
+		const std::vector<ConfigFile::location>&	get_location()const{return (this->_location);};
+		std::string 								get_index()const {return (this->_index);};
 
 		void										set_config(std::string configPath, int nb_of_server);
-		void										find_nb_of_server();
+		int											find_nb_of_server(std::string path);
 		void 										extract_config_file();
 		void										parse_listen(std::string str);
 		std::vector<std::string>					parse_location_listen(std::string str);

--- a/src/ConfigFile.cpp
+++ b/src/ConfigFile.cpp
@@ -8,7 +8,7 @@
 //#*     YP      YP       `"Ybbd8"'  8Y"Ybbd8"'   `"YbbdP"'   `"Ybbd8"'  88              "8"     *# 
 //#*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*#
 
-#include "ConfigFile.hpp"
+#include "../inc/ConfigFile.hpp"
 
 bool is_string_digit(const std::string& str){
 	for (std::string::const_iterator it = str.begin(); it != str.end(); ++it) {


### PR DESCRIPTION
added default construct to be able to create array of objects
added set_config(std::string configPath, int nb_of_server) to be able to parse a config file after creating the object by passing it the path to the config file and the index of the code block of the server you want to initialize, to be able to create multiple object in a loop
added int	find_nb_of_server(std::string path), that is possible to be called before passing a config file, to know how many server { } block there is in the config file path that you pass as an argument

Should work, I think